### PR TITLE
add alternative rethink dns main activity

### DIFF
--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -1669,6 +1669,7 @@
 	<item component="ComponentInfo{com.google.android.apps.wearables.maestro.companion/com.google.android.apps.wearables.maestro.companion.ui.ShortCutActivity}" drawable="pixel_buds" />
 	<item component="ComponentInfo{com.celzero.bravedns/com.celzero.bravedns.ui.HomeScreenActivity}" drawable="rethink" />
 	<item component="ComponentInfo{com.celzero.bravedns/com.celzero.bravedns.ui.LauncherAliasHome}" drawable="rethink" />
+	<item component="ComponentInfo{com.celzero.bravedns/com.celzero.bravedns.ui.LauncherAliasAppLock}" drawable="rethink" />
 	<item component="ComponentInfo{de.felixnuesse.extract/ca.pkay.rcloneexplorer.Activities.MainActivity}" drawable="round_sync" />
 	<item component="ComponentInfo{s1m.savertuner/com.draco.buoy.views.MainActivity}" drawable="savertuner" />
 	<item component="ComponentInfo{network.loki.messenger/network.loki.messenger.RoutingActivity}" drawable="session" />

--- a/app/src/main/res/xml/theme_resources.xml
+++ b/app/src/main/res/xml/theme_resources.xml
@@ -6830,6 +6830,7 @@
     <AppIcon name="com.fsck.k9/com.fsck.k9.activity.MainActivity" image="k_9_mail" />
     <AppIcon name="com.microsoft.translator/com.microsoft.translator.TranslateHomeActivity" image="translator" />
     <AppIcon name="com.celzero.bravedns/com.celzero.bravedns.ui.LauncherAliasHome" image="rethink" />
+    <AppIcon name="com.celzero.bravedns/com.celzero.bravedns.ui.LauncherAliasAppLock" image="rethink" />
     <AppIcon name="com.embermitre.hanping.cantodict.app.pro/app.geckodict.app.dict.hanping.android.MainActivity" image="hanping_cantonese" />
     <AppIcon name="com.embermitre.hanping.app.pro/app.geckodict.app.dict.hanping.android.MainActivity" image="hanping_chinese_pro" />
     <AppIcon name="app.linkwarden/app.linkwarden.MainActivity" image="linkwarden" />


### PR DESCRIPTION
Rethink DNS seems to have two main activities, `com.celzero.bravedns/.ui.LauncherAliasHome` and `com.celzero.bravedns/.ui.activity.LauncherAliasAppLock`, which for some reason on my phone the `LauncherAliasAppLock` is the one being used on the launcher. I think keeping both is okay.